### PR TITLE
Added --ip to bind the web server to only one ip address and not all available

### DIFF
--- a/app.py
+++ b/app.py
@@ -851,7 +851,7 @@ if __name__ == "__main__":
     # Parse any argument passed from command line
     parser = argparse.ArgumentParser(description='PiCamera2 WebUI')
     parser.add_argument('--port', type=int, default=8080, help='Port number to run the web server on')
-    parser.add_argument('--ip', type=str, default='0.0.0.0', help='IP to which the Server is bound to')
+    parser.add_argument('--ip', type=str, default='0.0.0.0', help='IP to which the web server is bound to')
     args = parser.parse_args()
     
     app.run(host=args.ip, port=args.port)

--- a/app.py
+++ b/app.py
@@ -851,6 +851,7 @@ if __name__ == "__main__":
     # Parse any argument passed from command line
     parser = argparse.ArgumentParser(description='PiCamera2 WebUI')
     parser.add_argument('--port', type=int, default=8080, help='Port number to run the web server on')
+    parser.add_argument('--ip', type=str, default='0.0.0.0', help='IP to which the Server is bound to')
     args = parser.parse_args()
     
-    app.run(host='0.0.0.0', port=args.port)
+    app.run(host=args.ip, port=args.port)


### PR DESCRIPTION
I've added a basic implementation to the Arg parser, so if needed, the Flask Server can be bound to only one Interface/Address. 

(Eg. 127.0.0.1 for only loopback access.) 

This is used to prevent flask to bind to addresses that would expose itself to external traffic and would be needed if all access is passed through a reverse proxy. 

Sample Usage: 

```
python3 app.py --ip 127.0.0.1
``` 

Note: Help Message may need to be improved, but I just wanted to quickly try if it works which it does. 
And I've checked, it should not break existing instances when a new version is pulled. 