### PR TITLE
fix typo "trigger"

### DIFF
--- a/templates/camera_info.html
+++ b/templates/camera_info.html
@@ -317,7 +317,7 @@
                             <!-- Enable GPIO Button -->
                             <div class="form-check form-switch">
                               <input class="form-check-input" type="checkbox" role="switch" id="enableGPIO" onchange="adjustSwitchSetting('enableGPIO')">
-                              <label for="enableGPIO" >Enable: Using button to tigger camera</label>
+                              <label for="enableGPIO" >Enable: Using button to trigger camera</label>
                           </div>
                             <div class="accordion accordion-flush" id="accordionFlushExample">
                               <div class="accordion-item">


### PR DESCRIPTION
Noticed a small typo in the UI. Updated the word "tigger" to "trigger".