### PR TITLE
Fixes error in theme switcher and adds samesite setting in set-cookie header

### DIFF
--- a/app.py
+++ b/app.py
@@ -23,6 +23,8 @@ from libcamera import Transform, controls
 # Init Flask
 app = Flask(__name__)
 app.secret_key = secrets.token_hex(16)  # Generates a random 32-character hexadecimal string
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value
+app.config["SESSION_COOKIE_SAMESITE"] = "None"
 Picamera2.set_logging(Picamera2.DEBUG)
 
 # Get global camera information
@@ -584,7 +586,7 @@ def inject_theme():
 @app.route('/set_theme/<theme>')
 def set_theme(theme):
     session['theme'] = theme
-    return 
+    return jsonify(success=True, ok=True, message="Theme updated successfully")
 
 # Define your 'home' route
 @app.route('/')


### PR DESCRIPTION
Currently switching themes results in both server-side and client side errors.

Server side:

ERROR:app:Exception on /set_theme/dark [GET]
Traceback (most recent call last):
  File "/root/picamera2-WebUI/.venv/lib/python3.11/site-packages/flask/app.py", line 1511, in wsgi_app
    response = self.full_dispatch_request()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/picamera2-WebUI/.venv/lib/python3.11/site-packages/flask/app.py", line 920, in full_dispatch_request
    return self.finalize_request(rv)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/picamera2-WebUI/.venv/lib/python3.11/site-packages/flask/app.py", line 939, in finalize_request
    response = self.make_response(rv)
               ^^^^^^^^^^^^^^^^^^^^^^
  File "/root/picamera2-WebUI/.venv/lib/python3.11/site-packages/flask/app.py", line 1212, in make_response
    raise TypeError(
TypeError: The view function for 'set_theme' did not return a valid response. The function either returned None or ended without a return statement.


The root cause is that the route ends with a bare "return", which probably translates to "return None", and that makes Flask erroring out. The error is reported back to the client with an 5xx error code, which makes it log an error on the JS console.


Changing the return statement to return the "ok" object makes both server and client happy :) 

Also, on the console there were messages about the cookie samesite setting missing, now it is set explicitly to the most permissive value.
