### PR TITLE
Add Docker support for CamUI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git
+.gitignore
+__pycache__
+*.pyc
+*.pyo
+*.egg-info
+dist
+build
+.env
+*.md
+LICENSE
+Dockerfile
+.dockerignore
+static/gallery/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,52 @@
+# CamUI for PiCamera2 - Docker
+# Must be built and run on a Raspberry Pi (ARM) with camera connected.
+#
+# Build:
+#   docker build -t camui .
+#
+# Run (camera access requires --privileged or explicit device mapping):
+#   docker run --rm -it --privileged \
+#     -p 8080:8080 \
+#     -v /run/udev:/run/udev:ro \
+#     -v camui-gallery:/app/static/gallery \
+#     camui
+#
+
+FROM debian:bookworm
+
+# Add Raspberry Pi apt repository for libcamera / picamera2
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gnupg curl ca-certificates \
+    && curl -fsSL https://archive.raspberrypi.com/debian/raspberrypi.gpg.key \
+       | gpg --dearmor -o /usr/share/keyrings/raspberrypi-archive-keyring.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/raspberrypi-archive-keyring.gpg] http://archive.raspberrypi.com/debian/ bookworm main" \
+       > /etc/apt/sources.list.d/raspi.list \
+    && apt-get update && apt-get install -y --no-install-recommends \
+    python3 \
+    python3-picamera2 \
+    python3-libcamera \
+    python3-flask \
+    python3-pil \
+    libcamera-tools \
+    ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy application files
+COPY app.py .
+COPY diagnostics.py .
+COPY camera_controls_db.json .
+COPY camera-module-info.json .
+COPY gpio_map.json .
+COPY camera-last-config.json .
+COPY connected_cameras_config.json .
+COPY templates/ templates/
+COPY static/ static/
+
+# Create gallery directory for captured images
+RUN mkdir -p /app/static/gallery /app/static/camera_profiles
+
+EXPOSE 8080
+
+CMD ["python3", "app.py", "--ip", "0.0.0.0", "--port", "8080"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  camui:
+    build: .
+    privileged: true
+    network_mode: host
+    ipc: host
+    pid: host
+    command: ["python3", "app.py", "--ip", "0.0.0.0", "--port", "8080"]
+    devices:
+      - /dev:/dev
+    shm_size: "512m"
+    volumes:
+      - /run/udev:/run/udev:ro
+      - /dev/dma_heap:/dev/dma_heap
+      - camui-gallery:/app/static/gallery
+    restart: unless-stopped
+
+volumes:
+  camui-gallery:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+flask
+picamera2
+Pillow


### PR DESCRIPTION
## Summary
- Adds `Dockerfile` using `debian:bookworm` with Raspberry Pi apt repo for `python3-picamera2` and `python3-libcamera`
- Adds `docker-compose.yml` with privileged mode, host networking, DMA heap access, and configurable port
- Adds `requirements.txt` and `.dockerignore`

## Test plan
- [x] Tested on Raspberry Pi 5 with IMX708 wide camera module
- [x] Camera detection and initialization works in container
- [x] DMA memory allocation works with host namespace sharing
- [x] Flask web server starts and serves on configured port