### PR TITLE
add release() after snapshot

### DIFF
--- a/app.py
+++ b/app.py
@@ -851,6 +851,7 @@ class CameraObject:
             filepath = os.path.join(app.config['upload_folder'], image_name)
             request = self.picam2.capture_request()
             request.save("main", f'{filepath}.jpg')
+            request.release()
             print(f"Image captured successfully. Path: {filepath}")
             return f'{filepath}.jpg'
         except Exception as e:


### PR DESCRIPTION
Hi, 

first of all thanks for creating this application, really easy to use and working well.

I had one issue though while using it: I used the "http://<ip>:<port>/snapshot_0" to retrieve images from a python script on a different computer, but after about 3 pulls CamUI freezes. For me this was fixed by adding the release in the snapshot function. 

I thought instead of making an issue, i can just do the pull request :) hope thats alright for this tiny change.

Thanks again and best regards
menno